### PR TITLE
Fix background gradient styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,10 +5,10 @@
     @apply scroll-smooth scroll-pt-[100px] min-h-screen;
   }
   body {
-    @apply bg-gradient-to-br from-[#94F4C0]/40 via-[#C9F7FA]/30 to-[#96E4FC]/40;
     background-image:
       radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.2), transparent 50%),
-      radial-gradient(circle at 80% 70%, rgba(255, 255, 255, 0.15), transparent 50%);
+      radial-gradient(circle at 80% 70%, rgba(255, 255, 255, 0.15), transparent 50%),
+      linear-gradient(135deg, rgba(148, 244, 192, 0.40), rgba(201, 247, 250, 0.30), rgba(150, 228, 252, 0.40));
     background-blend-mode: overlay;
   }
 }


### PR DESCRIPTION
Combine background gradients in `src/index.css` to prevent the Tailwind linear gradient from being overridden.

---
<a href="https://cursor.com/background-agent?bcId=bc-9be0b6dc-5b1f-4bc3-bf24-2202dce9dcbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9be0b6dc-5b1f-4bc3-bf24-2202dce9dcbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

